### PR TITLE
Small changes post andrew meeting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "catseye",
-    "version": "0.1.72",
+    "version": "0.1.73",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "catseye",
-            "version": "0.1.72",
+            "version": "0.1.73",
             "dependencies": {
                 "@emotion/react": "^11.9.3",
                 "@emotion/styled": "^11.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "catseye",
-    "version": "0.1.71",
+    "version": "0.1.72",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "catseye",
-            "version": "0.1.71",
+            "version": "0.1.72",
             "dependencies": {
                 "@emotion/react": "^11.9.3",
                 "@emotion/styled": "^11.9.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/horvathaa/catseye-vscode"
     },
     "publisher": "ahorvath",
-    "version": "0.1.71",
+    "version": "0.1.72",
     "engines": {
         "vscode": "^1.57.0"
     },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "url": "https://github.com/horvathaa/catseye-vscode"
     },
     "publisher": "ahorvath",
-    "version": "0.1.72",
+    "version": "0.1.73",
     "engines": {
         "vscode": "^1.57.0"
     },

--- a/source/anchorFunctions/anchor.ts
+++ b/source/anchorFunctions/anchor.ts
@@ -760,38 +760,6 @@ export function createRangesFromAnnotation(
     )
 }
 
-// Function to make VS Code decoration objects (the highlights that appear in the editor) with our metadata added
-const createDecorationOptions = (
-    ranges: AnnotationRange[],
-    annotationList: Annotation[]
-): vscode.DecorationOptions[] => {
-    // console.log('annotationList', annotationList, 'ranges', ranges);
-    return ranges.map((r) => {
-        let markdownArr = new Array<vscode.MarkdownString>()
-        markdownArr.push(
-            new vscode.MarkdownString(
-                annotationList.find((a) => a.id === r.annotationId)?.annotation
-            )
-        )
-        const showAnnoInWebviewCommand = vscode.Uri.parse(
-            `command:catseye.showAnnoInWebview?${encodeURIComponent(
-                JSON.stringify(r.annotationId)
-            )}`
-        )
-        let showAnnoInWebviewLink: vscode.MarkdownString =
-            new vscode.MarkdownString()
-        showAnnoInWebviewLink.isTrusted = true
-        showAnnoInWebviewLink.appendMarkdown(
-            `[Show Annotation](${showAnnoInWebviewCommand})`
-        )
-        markdownArr.push(showAnnoInWebviewLink)
-        return {
-            range: r.range,
-            hoverMessage: markdownArr,
-        }
-    })
-}
-
 export interface AnnotationRange extends AnnotationAnchorPair {
     anchorText: string
     range: vscode.Range
@@ -984,19 +952,12 @@ export const addHighlightsToEditor = (
 
             setAnnotationList(newAnnotationList.concat(unanchoredAnnotations))
             unanchoredAnnotations.length && view?.updateDisplay(annotationList)
-
             try {
-                const decorationOptions: vscode.DecorationOptions[] =
-                    createDecorationOptions(validRanges, newAnnotationList)
-                text.setDecorations(annotationDecorations, decorationOptions)
+                text.setDecorations(annotationDecorations, validRanges)
                 refreshFoldingRanges()
             } catch (error) {
                 console.error("Couldn't highlight: ", error)
             }
-
-            // if (vscode.workspace.workspaceFolders) {
-            //     view?.updateDisplay(newAnnotationList)
-            // }
         }
     }
 

--- a/source/anchorFunctions/anchor.ts
+++ b/source/anchorFunctions/anchor.ts
@@ -766,7 +766,7 @@ export interface AnnotationRange extends AnnotationAnchorPair {
     valid?: boolean
 }
 
-interface AnnotationAnchorPair {
+export interface AnnotationAnchorPair {
     annotationId: string
     anchorId: string | string[]
 }
@@ -829,7 +829,9 @@ export const addTempAnnotationHighlight = (
     const ranges = anchors.map((a) => createRangeFromAnchorObject(a))
     const decorationObjects: vscode.DecorationOptions[] = ranges.map((r) => {
         let markdownArr = new Array<vscode.MarkdownString>()
-        markdownArr.push(new vscode.MarkdownString('New Merged Anchor Point'))
+        markdownArr.push(
+            new vscode.MarkdownString("New Annotation's Anchor Point")
+        )
         return {
             range: r,
             hoverMessage: markdownArr,

--- a/source/anchorFunctions/anchor.ts
+++ b/source/anchorFunctions/anchor.ts
@@ -830,7 +830,7 @@ export const addTempAnnotationHighlight = (
     const decorationObjects: vscode.DecorationOptions[] = ranges.map((r) => {
         let markdownArr = new Array<vscode.MarkdownString>()
         markdownArr.push(
-            new vscode.MarkdownString("New Annotation's Anchor Point")
+            new vscode.MarkdownString("New annotation's anchor point")
         )
         return {
             range: r,
@@ -956,6 +956,14 @@ export const addHighlightsToEditor = (
             unanchoredAnnotations.length && view?.updateDisplay(annotationList)
             try {
                 text.setDecorations(annotationDecorations, validRanges)
+                refreshFoldingRanges()
+            } catch (error) {
+                console.error("Couldn't highlight: ", error)
+            }
+        } else {
+            // no ranges to highlight for this file -- reset
+            try {
+                text.setDecorations(annotationDecorations, [])
                 refreshFoldingRanges()
             } catch (error) {
                 console.error("Couldn't highlight: ", error)

--- a/source/anchorFunctions/old/reattach.ts
+++ b/source/anchorFunctions/old/reattach.ts
@@ -793,3 +793,36 @@ const generateLineMetadata = (h: {
 
 // const hover = await hoverController.provideAnnotationCreationHover(textEditor.document, activeSelection.end);
 // console.log('hover', hover);
+
+// Function to make VS Code decoration objects (the highlights that appear in the editor) with our metadata added
+// replaced in favor of HoverController -- bring back if hover controller does not work for some reason
+// const createDecorationOptions = (
+//     ranges: AnnotationRange[],
+//     annotationList: Annotation[]
+// ): vscode.DecorationOptions[] => {
+//     // console.log('annotationList', annotationList, 'ranges', ranges);
+//     return ranges.map((r) => {
+//         let markdownArr = new Array<vscode.MarkdownString>()
+//         markdownArr.push(
+//             new vscode.MarkdownString(
+//                 annotationList.find((a) => a.id === r.annotationId)?.annotation
+//             )
+//         )
+//         const showAnnoInWebviewCommand = vscode.Uri.parse(
+//             `command:catseye.showAnnoInWebview?${encodeURIComponent(
+//                 JSON.stringify(r.annotationId)
+//             )}`
+//         )
+//         let showAnnoInWebviewLink: vscode.MarkdownString =
+//             new vscode.MarkdownString()
+//         showAnnoInWebviewLink.isTrusted = true
+//         showAnnoInWebviewLink.appendMarkdown(
+//             `[Show Annotation](${showAnnoInWebviewCommand})`
+//         )
+//         markdownArr.push(showAnnoInWebviewLink)
+//         return {
+//             range: r.range,
+//             hoverMessage: markdownArr,
+//         }
+//     })
+// }

--- a/source/anchorFunctions/translateChangesHelpers.ts
+++ b/source/anchorFunctions/translateChangesHelpers.ts
@@ -9,8 +9,6 @@ import {
     tabSize,
     insertSpaces,
     annotationList,
-    deletedAnnotations,
-    setDeletedAnnotationList,
     selectedAnnotationsNavigations,
     setSelectedAnnotationsNavigations,
     view,

--- a/source/authHelper/authHelper.ts
+++ b/source/authHelper/authHelper.ts
@@ -39,6 +39,7 @@ export const initializeAuth = async () => {
     const authSessionOptions: vscode.AuthenticationGetSessionOptions = {
         clearSessionPreference: false,
         createIfNone: true,
+        // forceNewSession: true, // -- use for debugging and screenshot grabbing of first time user experience
     }
     try {
         // create VS Code GitHub auth session

--- a/source/commands/commands.ts
+++ b/source/commands/commands.ts
@@ -20,6 +20,8 @@ import {
     selectedAnnotationsNavigations,
     setSelectedAnnotationsNavigations,
     astHelper,
+    setTempMergedAnchors,
+    tempMergedAnchors,
     // trackedFiles,
     // setTrackedFiles,
 } from '../extension'
@@ -165,6 +167,11 @@ export const createView = async (context: vscode.ExtensionContext) => {
                         )
                         break
                     }
+                    case 'removeTempMergeAnchor': {
+                        const { anchorsToRemove } = message
+                        viewHelper.handleRemoveTempMergeAnchor(anchorsToRemove)
+                        break
+                    }
                     case 'findMatchingAnchors': {
                         const { annotations } = message
                         viewHelper.handleFindMatchingAnchors(annotations)
@@ -279,6 +286,7 @@ export const createNewAnnotation = async () => {
                 : activeTextEditor.document.uri.fsPath
             const anc = anchor.createAnchorFromRange(r)
             const anchorId = uuidv4()
+
             const createdTimestamp = new Date().getTime()
 
             const stableGitUrl = utils.getGithubUrl(
@@ -349,6 +357,11 @@ export const createNewAnnotation = async () => {
                 surroundingCode: surrounding,
                 anchorType,
             }
+            setTempMergedAnchors(anchorObject)
+            anchor.addTempAnnotationHighlight(
+                tempMergedAnchors,
+                activeTextEditor
+            )
             const temp = {
                 id: newAnnoId,
                 anchors: [anchorObject],
@@ -377,7 +390,7 @@ export const createNewAnnotation = async () => {
                 lastEditTime: createdTimestamp,
             }
             setTempAnno(utils.buildAnnotation(temp))
-            view?.createNewAnno(anchorObject, annotationList)
+            view?.createNewAnno(newAnnoId, anchorObject, annotationList)
         })
 }
 

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -24,6 +24,7 @@ import ViewLoader from './view/ViewLoader'
 import { AstHelper } from './astHelper/astHelper'
 import { partition } from './utils/utils'
 import { saveAnnotations } from './firebase/functions/functions'
+import { HoverController } from './hovers/hoverController'
 const gitExtension = vscode.extensions.getExtension('vscode.git')?.exports
 export const gitApi = gitExtension?.getAPI(1)
 console.log('gitApi', gitApi)
@@ -300,11 +301,8 @@ export function activate(context: vscode.ExtensionContext) {
         true
     )
 
-    // let foldingRangeProviderDisposable =
-    //     vscode.languages.registerFoldingRangeProvider(
-    //         '*',
-    //         catseyeFoldingRangeProvider
-    //     )
+    const provider = new HoverController()
+    context.subscriptions.push(provider) // not sure if this is right
 
     /*************************************************************************************/
     /**************************************** DISPOSABLES ********************************/
@@ -331,7 +329,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(copyDisposable)
     context.subscriptions.push(cutDisposable)
 
-    // context.subscriptions.push(foldingRangeProviderDisposable)
+    // context.subscriptions.push(hoverProviderDisposable)
 }
 
 // // this method is called when your extension is deactivated

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -11,6 +11,7 @@
 import * as vscode from 'vscode'
 import firebase from './firebase/firebase'
 import {
+    AnchorObject,
     Annotation,
     AnnotationEvent,
     ChangeEvent,
@@ -56,6 +57,7 @@ export let trackedFiles: vscode.TextDocument[] = []
 export let astHelper: AstHelper = new AstHelper()
 export let eventsToTransmitOnSave: AnnotationEvent[] = []
 export let showResolved: boolean = false
+export let tempMergedAnchors: AnchorObject[] = []
 
 export const annotationDecorations =
     vscode.window.createTextEditorDecorationType({
@@ -197,6 +199,14 @@ export const setShowResolved = (newShowResolved: boolean): void => {
     showResolved = newShowResolved
 }
 
+export const setTempMergedAnchors = (
+    newTempMergedAnchors: AnchorObject | AnchorObject[]
+): void => {
+    tempMergedAnchors = Array.isArray(newTempMergedAnchors)
+        ? newTempMergedAnchors
+        : tempMergedAnchors.concat(newTempMergedAnchors)
+}
+
 // this method is called when the extension is activated
 // the extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -301,8 +311,7 @@ export function activate(context: vscode.ExtensionContext) {
         true
     )
 
-    const provider = new HoverController()
-    context.subscriptions.push(provider) // not sure if this is right
+    let hoverProviderDisposable = new HoverController()
 
     /*************************************************************************************/
     /**************************************** DISPOSABLES ********************************/
@@ -329,7 +338,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(copyDisposable)
     context.subscriptions.push(cutDisposable)
 
-    // context.subscriptions.push(hoverProviderDisposable)
+    context.subscriptions.push(hoverProviderDisposable)
 }
 
 // // this method is called when your extension is deactivated

--- a/source/hovers/hoverController.ts
+++ b/source/hovers/hoverController.ts
@@ -1,5 +1,4 @@
 import {
-    // CancellationToken,
     languages,
     Range,
     Disposable,
@@ -8,30 +7,25 @@ import {
     MarkdownString,
     Position,
     TextDocument,
-    // DecorationOptions,
 } from 'vscode'
 import { annotationList } from '../extension'
 import {
     createRangeFromAnchorObject,
-    // getAnchorsInCurrentFile,
     getAnchorsWithGitUrl,
 } from '../anchorFunctions/anchor'
 import {
     getAnnotationsWithStableGitUrl,
     getStableGitHubUrl,
 } from '../utils/utils'
-const maxSmallIntegerV8 = 2 ** 30 // Max number that can be stored in V8's smis (small integers)
+const maxSmallIntegerV8 = 2 ** 30
 export class HoverController implements Disposable {
-    // private readonly _disposable: Disposable;
     private _hoverProviderDisposable: Disposable | undefined
-    // private _uri: Uri | undefined
 
     constructor() {
         this.register()
     }
 
     dispose() {
-        // this._uri = undefined
         this._hoverProviderDisposable?.dispose()
     }
 

--- a/source/hovers/hoverController.ts
+++ b/source/hovers/hoverController.ts
@@ -1,60 +1,106 @@
-// import { CancellationToken, languages, Range, Disposable, Hover, Uri, MarkdownString, Position, TextDocument, DecorationOptions } from 'vscode';
-// const maxSmallIntegerV8 = 2 ** 30; // Max number that can be stored in V8's smis (small integers)
-// export class HoverController implements Disposable {
-//     // private readonly _disposable: Disposable;
-//     private _hoverProviderDisposable: Disposable | undefined;
-//     private _uri: Uri | undefined;
+import {
+    // CancellationToken,
+    languages,
+    Range,
+    Disposable,
+    Hover,
+    Uri,
+    MarkdownString,
+    Position,
+    TextDocument,
+    // DecorationOptions,
+} from 'vscode'
+import { annotationList } from '../extension'
+import {
+    createRangeFromAnchorObject,
+    // getAnchorsInCurrentFile,
+    getAnchorsWithGitUrl,
+} from '../anchorFunctions/anchor'
+import {
+    getAnnotationsWithStableGitUrl,
+    getStableGitHubUrl,
+} from '../utils/utils'
+const maxSmallIntegerV8 = 2 ** 30 // Max number that can be stored in V8's smis (small integers)
+export class HoverController implements Disposable {
+    // private readonly _disposable: Disposable;
+    private _hoverProviderDisposable: Disposable | undefined
+    // private _uri: Uri | undefined
 
-//     constructor() {
-//         // this._disposable;
-//         this.register();
-//     }
+    constructor() {
+        this.register()
+    }
 
-//     dispose() {
-//         this._uri = undefined;
-//         this._hoverProviderDisposable?.dispose();
-//     }
+    dispose() {
+        // this._uri = undefined
+        this._hoverProviderDisposable?.dispose()
+    }
 
-//     async provideAnnotationCreationHover(
-//         document: TextDocument,
-//         position: Position,
+    async provideAnnotationCreationHover(
+        document: TextDocument,
+        position: Position
+    ): Promise<Hover | undefined> {
+        const range = document.validateRange(
+            new Range(
+                position.line,
+                position.character,
+                position.line,
+                maxSmallIntegerV8
+            )
+        )
+        const docGitUrl = getStableGitHubUrl(document.uri.fsPath)
+        const annosInFile = getAnnotationsWithStableGitUrl(
+            annotationList,
+            docGitUrl
+        )
+        const anchorsInFile = getAnchorsWithGitUrl(docGitUrl).filter(
+            (a) => a.anchored
+        )
+        const anchorsThatContainPosition = anchorsInFile.filter((a) => {
+            const range = createRangeFromAnchorObject(a)
+            return range.contains(position)
+        })
+        if (!anchorsThatContainPosition.length) {
+            return undefined
+        }
+        const hoverArr: MarkdownString[] = anchorsThatContainPosition.flatMap(
+            (anchor) => {
+                let markdownArr = new Array<MarkdownString>()
+                markdownArr.push(
+                    new MarkdownString(
+                        annosInFile.find(
+                            (a) => a.id === anchor.parentId
+                        )?.annotation
+                    )
+                )
+                const showAnnoInWebviewCommand = Uri.parse(
+                    `command:catseye.showAnnoInWebview?${encodeURIComponent(
+                        JSON.stringify(anchor.parentId)
+                    )}`
+                )
+                let showAnnoInWebviewLink: MarkdownString = new MarkdownString()
+                showAnnoInWebviewLink.isTrusted = true
+                showAnnoInWebviewLink.appendMarkdown(
+                    `[Show Annotation](${showAnnoInWebviewCommand})`
+                )
+                return markdownArr.concat(showAnnoInWebviewLink)
+            }
+        )
 
-//     ) : Promise<Hover | undefined> {
+        return new Hover(hoverArr, range)
+    }
 
-//         const range = document.validateRange(
-//             new Range(
-//                 position.line,
-//                 position.character,
-//                 position.line,
-//                 maxSmallIntegerV8
-//             )
-//         )
+    private register() {
+        const subscriptions = []
 
-//         console.log('creating hover???');
+        subscriptions.push(
+            languages.registerHoverProvider(
+                { scheme: 'file' },
+                {
+                    provideHover: this.provideAnnotationCreationHover,
+                }
+            )
+        )
 
-//         return new Hover(createAnnotationWebviewLink, range);
-
-
-//     }
-
-//     private register() {
-//         const subscriptions = [];
-
-//         subscriptions.push(
-//             languages.registerHoverProvider(
-//                 { scheme: "file" },
-//                 {
-//                     provideHover: this.provideAnnotationCreationHover
-//                 },
-//             ),
-//         );
-		
-
-// 		this._hoverProviderDisposable = Disposable.from(...subscriptions);
-//     }
-
-//     // private annotationCreationMarkdown() {
-     
-//     //    return createAnnotationWebviewLink;
-//     // }
-// }
+        this._hoverProviderDisposable = Disposable.from(...subscriptions)
+    }
+}

--- a/source/utils/utils.ts
+++ b/source/utils/utils.ts
@@ -354,7 +354,7 @@ export const checkIfChangeIncludesAnchor = (
 }
 
 const getShikiTheme = (pl: string): string => {
-    let theme
+    let theme = ''
     if (pl === 'css') {
         theme = stringToShikiThemes[pl]
     } else if (stringToShikiThemes[currentColorTheme]) {

--- a/source/view/ViewLoader.ts
+++ b/source/view/ViewLoader.ts
@@ -182,6 +182,7 @@ export default class ViewLoader {
     }
 
     public createNewAnno(
+        annoId: string,
         anchorObject: AnchorObject,
         annotationList: Annotation[]
     ) {
@@ -189,7 +190,8 @@ export default class ViewLoader {
             this._panel.webview.postMessage({
                 command: 'newAnno',
                 payload: {
-                    anchorObject,
+                    annoId,
+                    anchorObject: [anchorObject],
                     annotations: annotationList,
                 },
             })
@@ -238,6 +240,17 @@ export default class ViewLoader {
                     anchors,
                     removedAnchorIds,
                     usedAnnoIds,
+                },
+            })
+        }
+    }
+
+    public sendNewAnchorForNewAnnotation(anchor: AnchorObject) {
+        if (this._panel && this._panel.webview) {
+            this._panel.webview.postMessage({
+                command: 'newAnchorForNewAnnotation',
+                payload: {
+                    anchor,
                 },
             })
         }

--- a/source/view/app/catseye.tsx
+++ b/source/view/app/catseye.tsx
@@ -156,7 +156,6 @@ const CatseyePanel: React.FC<Props> = ({
     // }
 
     const filtersUpdated = (filters: FilterOptions): void => {
-        console.log(filters)
         setFilterOptions(filters)
     }
 
@@ -217,11 +216,11 @@ const CatseyePanel: React.FC<Props> = ({
     }
 
     const filterMine = (annos: Annotation[]): Annotation[] => {
-        return annos.filter((anno) => anno['authorId'] === userId)
+        return annos.filter((anno) => anno['authorId'] === uid)
     }
 
     const filterOthers = (annos: Annotation[]): Annotation[] => {
-        return annos.filter((anno) => anno['authorId'] !== userId)
+        return annos.filter((anno) => anno['authorId'] !== uid)
     }
 
     const filterAuthors = (annos: Annotation[], optionGroup: OptionGroup) => {
@@ -233,7 +232,8 @@ const CatseyePanel: React.FC<Props> = ({
         } else if (
             optionGroup.options.filter(
                 (option) =>
-                    option['name'] === AuthorOptions.mine &&
+                    (option['name'] === AuthorOptions.mine ||
+                        option['name'] === userName) &&
                     option['selected'] === true
             ).length > 0
         ) {
@@ -368,7 +368,7 @@ const CatseyePanel: React.FC<Props> = ({
             {annosToConsolidate.length > 0 ? (
                 <MergeAnnotations
                     vscode={vscode}
-                    username={username ?? ''}
+                    username={userName ?? ''}
                     userId={userId ?? ''}
                     notifyDone={notifyMergeDone}
                     annotations={annosToConsolidate}
@@ -381,6 +381,7 @@ const CatseyePanel: React.FC<Props> = ({
                         // showKeyboardShortcuts={showKeyboardShortcuts}
                         filtersUpdated={filtersUpdated}
                         vscode={vscode}
+                        githubUsername={userName ?? ''}
                     />
                     {/* <MassOperationsBar
                         massOperationSelected={massOperationSelected}

--- a/source/view/app/catseye.tsx
+++ b/source/view/app/catseye.tsx
@@ -52,7 +52,13 @@ const CatseyePanel: React.FC<Props> = ({
         window.username ? window.username : ''
     )
     const [uid, setUserId] = useState(window.userId ? window.userId : '')
-    const [anchorObject, setAnchorObject] = useState<AnchorObject | null>(null)
+    const [newAnchors, _setNewAnchors] = useState<AnchorObject[]>([])
+    const newAnchorsRef = React.useRef(newAnchors)
+    const setNewAnchors = (newAnchorsArr: AnchorObject[]): void => {
+        newAnchorsRef.current = newAnchorsArr
+        _setNewAnchors(newAnchorsArr)
+    }
+    const [newAnnotationId, setNewAnnotationId] = useState<string>('')
     const [showNewAnnotation, setShowNewAnnotation] = useState<boolean>(false)
     const [annosToConsolidate, setAnnosToConsolidate] = useState<Annotation[]>(
         []
@@ -90,8 +96,9 @@ const CatseyePanel: React.FC<Props> = ({
                 // console.log('message', message)
                 return
             case 'newAnno':
-                setAnchorObject(message.payload.anchorObject)
+                setNewAnchors(message.payload.anchorObject)
                 setShowNewAnnotation(true)
+                setNewAnnotationId(message.payload.annoId)
                 const newAnnoDiv: HTMLElement | null =
                     document.getElementById('NewAnnotation')
                 newAnnoDiv?.scrollIntoView({
@@ -99,6 +106,11 @@ const CatseyePanel: React.FC<Props> = ({
                     block: 'center',
                     inline: 'center',
                 })
+                return
+            case 'newAnchorForNewAnnotation':
+                setNewAnchors(
+                    newAnchorsRef.current.concat(message.payload.anchor)
+                )
                 return
         }
     }
@@ -386,9 +398,10 @@ const CatseyePanel: React.FC<Props> = ({
                     {/* <MassOperationsBar
                         massOperationSelected={massOperationSelected}
                     ></MassOperationsBar> */}
-                    {showNewAnnotation && anchorObject ? (
+                    {showNewAnnotation && newAnchors ? (
                         <NewAnnotation
-                            anchorObject={anchorObject}
+                            newAnnoId={newAnnotationId}
+                            newAnchors={newAnchors}
                             vscode={vscode}
                             notifyDone={notifyDone}
                         />

--- a/source/view/app/components/annotationComponents/CatseyeButton.tsx
+++ b/source/view/app/components/annotationComponents/CatseyeButton.tsx
@@ -12,6 +12,7 @@ interface Props {
     buttonClicked: (e: React.SyntheticEvent) => void
     name: string
     icon: React.ReactElement
+    style?: React.CSSProperties
     noMargin?: boolean
     disabled?: boolean
 }
@@ -20,9 +21,16 @@ const catseyeButton: React.FC<Props> = ({
     buttonClicked = () => {},
     name,
     icon,
+    style,
     noMargin: noMargin = false,
     disabled: disabled = false,
 }) => {
+    const inlineStyle: React.CSSProperties | undefined =
+        disabled && style
+            ? { cursor: 'default', pointerEvents: 'none', ...style }
+            : style
+            ? style
+            : undefined
     return (
         <React.Fragment>
             <div
@@ -31,11 +39,7 @@ const catseyeButton: React.FC<Props> = ({
                     buttonClicked(e)
                 }}
                 className={styles['DropdownItemOverwrite']}
-                style={
-                    disabled
-                        ? { cursor: 'default', pointerEvents: 'none' }
-                        : undefined
-                }
+                style={inlineStyle}
             >
                 <div
                     className={styles['DropdownIconsWrapper']}

--- a/source/view/app/components/annotationComponents/anchorCarousel.tsx
+++ b/source/view/app/components/annotationComponents/anchorCarousel.tsx
@@ -10,6 +10,8 @@ import {
 
 import { PastVersions } from './pastVersions'
 import { PotentialVersions } from './potentialVersions'
+import { TbAnchor, TbAnchorOff } from 'react-icons/tb'
+import { IconButton, Tooltip } from '@mui/material'
 
 interface Props {
     priorVersions?: AnchorOnCommit[]
@@ -178,17 +180,33 @@ const AnchorCarousel: React.FC<Props> = ({
                 flexDirection: 'column',
             }}
         >
-            {/* PRIOR VERISONS  */}
+            {/* <div style={{ display: 'flex', flexDirection: 'row' }}>
+                {/* PRIOR VERISONS  */}
+            {/* {} */}
             {pastVersions ? (
                 <PastVersions
                     pastVersions={pastVersions}
                     handleClick={handleClick}
                     displayBefore={displayBefore}
                     displayAfter={displayAfter}
+                    anchorIcon={
+                        currentAnchorObject.anchored ? (
+                            <Tooltip title={'Currently anchored'}>
+                                <IconButton size="small">
+                                    <TbAnchor />
+                                </IconButton>
+                            </Tooltip>
+                        ) : (
+                            <Tooltip title={'Un-anchored'}>
+                                <IconButton size="small">
+                                    <TbAnchorOff />
+                                </IconButton>
+                            </Tooltip>
+                        )
+                    }
                 />
-            ) : // <div style={{ display: 'flex', flexDirection: 'row' }}>
-
-            null}
+            ) : null}
+            {/* </div> */}
             {/* POTENTIAL VERSIONS  */}
 
             {/* POTENTIAL VERSIONS -- lot of redundant code between this and prior versions - should fix */}

--- a/source/view/app/components/annotationComponents/anchorVersions.tsx
+++ b/source/view/app/components/annotationComponents/anchorVersions.tsx
@@ -37,6 +37,7 @@ const AnchorVersions: React.FC<Props> = ({
     const showPotentialAnchors = (anchor: AnchorObject): React.ReactElement => {
         const unanchorText = (
             <p
+                style={{ paddingBottom: 0 }}
                 onClick={() => setShowSuggestions(!showSuggestions)}
                 className={`${styles['SuggestionTitle']} ${styles['ReanchorTitle']}`}
             >
@@ -49,18 +50,23 @@ const AnchorVersions: React.FC<Props> = ({
         return (
             <>
                 <div
-                    style={{ display: 'flex', justifyContent: 'space-between' }}
+                    style={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        alignItems: 'center',
+                    }}
                 >
                     {unanchorText}{' '}
-                    <>
+                    <div style={{ display: 'flex', alignItems: 'center' }}>
                         {' '}
                         Manually Reanchor{' '}
                         <CatseyeButton
                             buttonClicked={() => requestManualReanchor(anchor)}
                             name="Manually Reanchor"
                             icon={<AnchorIcon fontSize="small" />}
+                            style={{ paddingLeft: '4px' }}
                         />
-                    </>
+                    </div>
                 </div>
                 {showSuggestions && (
                     <Carousel

--- a/source/view/app/components/annotationComponents/annotationCardHeader.tsx
+++ b/source/view/app/components/annotationComponents/annotationCardHeader.tsx
@@ -7,7 +7,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import ShareIcon from '@mui/icons-material/Share'
 import PushPinIcon from '@mui/icons-material/PushPin'
 import { Annotation } from '../../../../constants/constants'
-import UserProfile from './userProfile'
+import UserProfile, { UserIcon } from './userProfile'
 import CatseyeButton from './CatseyeButton'
 import { createTheme } from '@mui/material'
 import { useMediaQuery } from '@material-ui/core'
@@ -69,9 +69,19 @@ const CardHeader = ({
                         flexWrap: 'wrap',
                     }}
                 >
-                    <IconButton size="small">
-                        {anchored === true ? <TbAnchor /> : <TbAnchorOff />}
-                    </IconButton>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+                        <UserIcon
+                            githubUsername={annotation.githubUsername}
+                            style={{
+                                width: '20px',
+                                height: '20px',
+                            }}
+                            size={20}
+                        />
+                        <IconButton size="small">
+                            {anchored === true ? <TbAnchor /> : <TbAnchorOff />}
+                        </IconButton>
+                    </div>
                     <div
                         style={{
                             display: 'flex',

--- a/source/view/app/components/annotationComponents/pastVersions.tsx
+++ b/source/view/app/components/annotationComponents/pastVersions.tsx
@@ -1,9 +1,15 @@
 import { AnchorOnCommit } from '../../../../constants/constants'
 import * as React from 'react'
-import { formatTimestamp } from '../../utils/viewUtils'
+import {
+    formatTimestamp,
+    getActiveIndicatorIconProps,
+    getIndicatorIconProps,
+} from '../../utils/viewUtils'
 import Carousel from 'react-material-ui-carousel'
 import styles from '../../styles/versions.module.css'
 import { displayAnchorText } from '../../utils/viewUtilsTsx'
+// import { ExtendButtonBase, IconButtonTypeMap } from '@mui/material'
+import { ReactJSXElement } from '@emotion/react/types/jsx-namespace'
 
 interface PastVersionProps {
     handleClick: (e: React.SyntheticEvent, aId: string) => void
@@ -12,6 +18,7 @@ interface PastVersionProps {
     displayBefore?: (pv: AnchorOnCommit, index: number) => string | null
     displayAfter?: (pv: AnchorOnCommit, index: number) => string | null
     mergeSelection?: boolean
+    anchorIcon?: ReactJSXElement
 }
 
 export interface OldAnchorOnCommit extends AnchorOnCommit {
@@ -34,6 +41,7 @@ export const PastVersion: React.FC<PastVersionProps> = ({
     displayBefore,
     displayAfter,
     mergeSelection,
+    anchorIcon,
 }) => {
     const [pv, setPv] = React.useState<AnchorOnCommit>(pastVersion)
     React.useEffect(() => {
@@ -111,25 +119,37 @@ export const PastVersion: React.FC<PastVersionProps> = ({
                     : `${styles['AnchorContainer']}`
             }
         >
-            <span>
-                <i> {pv.path} </i>
-            </span>
-            {pv.anchor?.endLine - pv.anchor?.startLine > 0 ? (
-                <span>
-                    lines {pv.anchor?.startLine + 1}-{pv.anchor?.endLine + 1} on{' '}
-                    {pv.branchName} {pv.commitHash !== '' ? ':' : null}{' '}
-                    {pv.commitHash.slice(0, 7)}
-                </span>
-            ) : (
-                <span>
-                    line {pv.anchor?.startLine + 1} on {pv.branchName}
-                    {pv.commitHash !== '' ? ':' : null}{' '}
-                    {pv.commitHash.slice(0, 6)}
-                </span>
-            )}
-            <span>
-                <i>created on {formatTimestamp(pv.createdTimestamp)}</i>
-            </span>
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    cursor: 'default',
+                }}
+            >
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    <span>
+                        <i> {pv.path} </i>
+                    </span>
+                    {pv.anchor?.endLine - pv.anchor?.startLine > 0 ? (
+                        <span>
+                            lines {pv.anchor?.startLine + 1}-
+                            {pv.anchor?.endLine + 1} on {pv.branchName}{' '}
+                            {pv.commitHash !== '' ? ':' : null}{' '}
+                            {pv.commitHash.slice(0, 7)}
+                        </span>
+                    ) : (
+                        <span>
+                            line {pv.anchor?.startLine + 1} on {pv.branchName}
+                            {pv.commitHash !== '' ? ':' : null}{' '}
+                            {pv.commitHash.slice(0, 6)}
+                        </span>
+                    )}
+                    <span>
+                        <i>created on {formatTimestamp(pv.createdTimestamp)}</i>
+                    </span>
+                </div>
+                {anchorIcon ? anchorIcon : null}
+            </div>
             <div
                 style={{
                     display: 'flex',
@@ -161,6 +181,7 @@ interface PastVersionsProps {
     handleClick: (e: React.SyntheticEvent, aId: string) => void
     displayBefore: (pv: AnchorOnCommit, index: number) => string | null
     displayAfter: (pv: AnchorOnCommit, index: number) => string | null
+    anchorIcon: ReactJSXElement
 }
 
 export const PastVersions: React.FC<PastVersionsProps> = ({
@@ -168,6 +189,7 @@ export const PastVersions: React.FC<PastVersionsProps> = ({
     displayBefore,
     displayAfter,
     pastVersions,
+    anchorIcon,
 }) => {
     const [versionsToRender, setVersionsToRender] = React.useState<
         AnchorOnCommit[]
@@ -195,37 +217,33 @@ export const PastVersions: React.FC<PastVersionsProps> = ({
         setVersionsToRender(versions)
     }, [pastVersions])
 
-    const activeProps =
-        versionsToRender.length === 1
-            ? { display: 'none' }
-            : {
-                  color: '#7fae42',
-                  '&:hover': {
-                      color: '#7fae4285',
-                  },
-                  transition: '200ms',
-              }
-
     return (
-        <Carousel
-            autoPlay={false}
-            index={versionsToRender.length - 1}
-            activeIndicatorIconButtonProps={{
-                style: activeProps,
-            }}
-        >
-            {versionsToRender.map((pv: AnchorOnCommit, index) => {
-                return (
-                    <PastVersion
-                        key={pv.id + index + 'carousel'}
-                        handleClick={handleClick}
-                        i={index}
-                        pastVersion={pv}
-                        displayAfter={displayAfter}
-                        displayBefore={displayBefore}
-                    />
-                )
-            })}
-        </Carousel>
+        <>
+            {/* {anchorIcon} */}
+            <Carousel
+                autoPlay={false}
+                index={versionsToRender.length - 1}
+                activeIndicatorIconButtonProps={{
+                    style: getActiveIndicatorIconProps(versionsToRender),
+                }}
+                indicatorIconButtonProps={{
+                    style: getIndicatorIconProps(versionsToRender),
+                }}
+            >
+                {versionsToRender.map((pv: AnchorOnCommit, index) => {
+                    return (
+                        <PastVersion
+                            key={pv.id + index + 'carousel'}
+                            handleClick={handleClick}
+                            i={index}
+                            pastVersion={pv}
+                            displayAfter={displayAfter}
+                            displayBefore={displayBefore}
+                            anchorIcon={anchorIcon}
+                        />
+                    )
+                })}
+            </Carousel>
+        </>
     )
 }

--- a/source/view/app/components/annotationComponents/potentialVersions.tsx
+++ b/source/view/app/components/annotationComponents/potentialVersions.tsx
@@ -7,6 +7,10 @@ import {
 } from '../../../../constants/constants' // we are confident enough } from '../../../../constants/constants'
 import Carousel from 'react-material-ui-carousel' // https://www.npmjs.com/package/react-material-ui-carousel
 import { displayAnchorText } from '../../utils/viewUtilsTsx'
+import {
+    getActiveIndicatorIconProps,
+    getIndicatorIconProps,
+} from '../../utils/viewUtils'
 
 interface PotentialVersionProps {
     handleClick: (e: React.SyntheticEvent, aId: string) => void
@@ -156,13 +160,10 @@ export const PotentialVersions: React.FC<PotentialVersionsProps> = ({
             autoPlay={false}
             index={0}
             activeIndicatorIconButtonProps={{
-                style: {
-                    color: '#dcdcaa5e',
-                    '&:hover': {
-                        color: '#dcdcaa5e',
-                    },
-                    transition: '200ms',
-                },
+                style: getActiveIndicatorIconProps(potentialVersions),
+            }}
+            indicatorIconButtonProps={{
+                style: getIndicatorIconProps(potentialVersions),
             }}
         >
             {potentialVersions.map((pv: PotentialAnchorObject, index) => {

--- a/source/view/app/components/annotationComponents/replyContainer.tsx
+++ b/source/view/app/components/annotationComponents/replyContainer.tsx
@@ -13,6 +13,7 @@ import styles from '../../styles/annotation.module.css'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
 import KeyboardDoubleArrowUpIcon from '@mui/icons-material/KeyboardDoubleArrowUp'
+import Tooltip from '@mui/material/Tooltip/Tooltip'
 
 interface Props {
     replying: boolean
@@ -75,41 +76,47 @@ const ReplyContainer: React.FC<Props> = ({
         if (hasBeenSelected.get(r.id)) {
             return (
                 <div className={styles['ReplyArrowBox']}>
-                    <ArrowDownwardIcon
-                        style={{ cursor: 'pointer' }}
-                        onClick={() => {
-                            setHasBeenSelected(
-                                new Map(hasBeenSelected.set(r.id, false))
-                            )
-                            handleSelectReply &&
-                                handleSelectReply(r.id, 'remove')
-                        }}
-                    />
+                    <Tooltip title={'Remove reply from merged annotation'}>
+                        <ArrowDownwardIcon
+                            style={{ cursor: 'pointer' }}
+                            onClick={() => {
+                                setHasBeenSelected(
+                                    new Map(hasBeenSelected.set(r.id, false))
+                                )
+                                handleSelectReply &&
+                                    handleSelectReply(r.id, 'remove')
+                            }}
+                        />
+                    </Tooltip>
                 </div>
             )
         } else {
             return (
                 <div className={styles['ReplyArrowBox']}>
-                    <KeyboardDoubleArrowUpIcon
-                        style={{ cursor: 'pointer' }}
-                        onClick={() => {
-                            setHasBeenSelected(
-                                new Map(hasBeenSelected.set(r.id, true))
-                            )
-                            handleSelectReply &&
-                                handleSelectReply(r.id, 'add', 'annotation')
-                        }}
-                    />
-                    <ArrowUpwardIcon
-                        style={{ cursor: 'pointer' }}
-                        onClick={() => {
-                            setHasBeenSelected(
-                                new Map(hasBeenSelected.set(r.id, true))
-                            )
-                            handleSelectReply &&
-                                handleSelectReply(r.id, 'add', 'reply')
-                        }}
-                    />
+                    <Tooltip title={'Add reply to merged annotation body'}>
+                        <KeyboardDoubleArrowUpIcon
+                            style={{ cursor: 'pointer' }}
+                            onClick={() => {
+                                setHasBeenSelected(
+                                    new Map(hasBeenSelected.set(r.id, true))
+                                )
+                                handleSelectReply &&
+                                    handleSelectReply(r.id, 'add', 'annotation')
+                            }}
+                        />
+                    </Tooltip>
+                    <Tooltip title={'Add reply to merged annotation'}>
+                        <ArrowUpwardIcon
+                            style={{ cursor: 'pointer' }}
+                            onClick={() => {
+                                setHasBeenSelected(
+                                    new Map(hasBeenSelected.set(r.id, true))
+                                )
+                                handleSelectReply &&
+                                    handleSelectReply(r.id, 'add', 'reply')
+                            }}
+                        />
+                    </Tooltip>
                 </div>
             )
         }

--- a/source/view/app/components/annotationComponents/textEditor.tsx
+++ b/source/view/app/components/annotationComponents/textEditor.tsx
@@ -76,6 +76,8 @@ const TextEditor: React.FC<Props> = ({
             'mergedTextArea'
         ) as HTMLTextAreaElement
         // not sure why this isnt actually setting the cursor position since the vals seem correct?
+        // update -- sets properly for double-click then delete, and regular highlight then delete, but
+        // NOT for ctrl+shift select? Weird? Not sure why? Probably gonna ignore for now
         if (textArea && setCursorAt) {
             textArea.focus()
             textArea.selectionStart = setCursorAt
@@ -241,7 +243,6 @@ const TextEditor: React.FC<Props> = ({
     }
 
     const handleSubmission = (shareWith: string) => {
-        console.log('how does this work again lol', shareWith)
         if (text.hasOwnProperty('comment')) {
             cancelHandler()
         }

--- a/source/view/app/components/annotationComponents/textEditor.tsx
+++ b/source/view/app/components/annotationComponents/textEditor.tsx
@@ -5,6 +5,7 @@
  * Split button is used for annotation creation support, while regular "submit" button is used for replies and snapshots.
  */
 import * as React from 'react'
+import cn from 'classnames'
 import SplitButton from './muiSplitButton'
 import styles from '../../styles/annotation.module.css'
 import FormGroup from '@mui/material/FormGroup'
@@ -36,6 +37,7 @@ interface Props {
         userText: string,
         selectedRange: Selection
     ) => void
+    setCursorAt?: number
 }
 // Having default props is weirdly supported in React, this way means showCancel is an optional
 // See: https://dev.to/bytebodger/default-props-in-react-typescript-2o5o
@@ -48,6 +50,7 @@ const TextEditor: React.FC<Props> = ({
     focus = true,
     placeholder = '',
     onChange,
+    setCursorAt,
 }) => {
     const [text, setText] = React.useState<any>(content)
     const [willBePinned, setWillBePinned] = React.useState<boolean>(false)
@@ -67,6 +70,18 @@ const TextEditor: React.FC<Props> = ({
     React.useEffect(() => {
         setText(content)
     }, [content])
+
+    React.useEffect(() => {
+        let textArea = document.getElementById(
+            'mergedTextArea'
+        ) as HTMLTextAreaElement
+        // not sure why this isnt actually setting the cursor position since the vals seem correct?
+        if (textArea && setCursorAt) {
+            textArea.focus()
+            textArea.selectionStart = setCursorAt
+            textArea.selectionEnd = setCursorAt
+        }
+    }, [setCursorAt])
 
     React.useEffect(() => {
         window.document.addEventListener('keydown', setClipboardText)
@@ -177,15 +192,15 @@ const TextEditor: React.FC<Props> = ({
     }
 
     const handleEnter = (e: React.KeyboardEvent): void => {
-        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        const key = e.key
+        const textArea = e.target as HTMLTextAreaElement
+        if ((e.ctrlKey || e.metaKey) && key === 'Enter') {
             submissionHandler(text, 'private', willBePinned)
             setText({
                 ...text,
                 replyContent: '',
             })
         } else if (hasSelectedRange && onChange) {
-            const key = e.key
-            const textArea = e.target as HTMLTextAreaElement
             if (key !== 'Backspace' && !(e.metaKey || e.ctrlKey || e.altKey)) {
                 // probably input event
                 // could add redundancy check to see if the value of the input changed as well uhguig
@@ -202,6 +217,11 @@ const TextEditor: React.FC<Props> = ({
             }
             setHasSelectedRange(false)
             setSelectedRange(null)
+        } else if (onChange && key === 'Backspace') {
+            onChange(textArea.value, '', {
+                startOffset: textArea.selectionStart - 1,
+                endOffset: textArea.selectionEnd,
+            })
         }
     }
 
@@ -228,13 +248,26 @@ const TextEditor: React.FC<Props> = ({
         submissionHandler(text, shareWith, willBePinned)
     }
 
+    const styleProps = text.hasOwnProperty('replyContent')
+        ? {
+              backgroundColor: textBoxBackground,
+              width: text.replyContent.length ? '80%' : '98%',
+              marginRight: '8px',
+          }
+        : { backgroundColor: textBoxBackground }
     // Ideally this textbox isn't a significantly different color and is not of fixed size.
     return (
-        <div className={styles['textboxContainer']}>
+        <div
+            className={cn({
+                [styles['textboxContainer']]: true,
+                [styles['inlineReply']]: text.hasOwnProperty('replyContent'),
+            })}
+        >
             <TextareaAutosize
+                id={setCursorAt !== undefined ? 'mergedTextArea' : ''}
                 minRows={1}
                 className={styles['textbox']}
-                style={{ backgroundColor: textBoxBackground }}
+                style={styleProps}
                 autoFocus={focus}
                 placeholder={placeholder}
                 value={
@@ -259,7 +292,11 @@ const TextEditor: React.FC<Props> = ({
                         <>
                             {!showCancel && text.replyContent.length ? (
                                 <button
-                                    className={styles['submit']}
+                                    className={cn({
+                                        [styles['submit']]: true,
+                                        [styles['inlineReply']]:
+                                            text.hasOwnProperty('replyContent'),
+                                    })}
                                     onClick={(e: React.SyntheticEvent) => {
                                         e.stopPropagation()
                                         // Is this a checker for Snapshots?

--- a/source/view/app/components/annotationComponents/userProfile.tsx
+++ b/source/view/app/components/annotationComponents/userProfile.tsx
@@ -11,6 +11,28 @@ import { formatTimestamp } from '../../utils/viewUtils'
 // import { breakpoints, formatTimestamp } from '../../utils/viewUtils'
 // import { createTheme } from '@mui/material'
 
+interface UserIconProps {
+    githubUsername: string
+    style?: React.CSSProperties
+    size?: number
+}
+
+export const UserIcon: React.FC<UserIconProps> = ({
+    githubUsername,
+    style,
+    size,
+}) => {
+    const sizeStr = size ? `?size=${size}` : '?size=40'
+    return (
+        <img
+            src={'https://github.com/' + githubUsername + '.png' + sizeStr}
+            className={`${styles['userProfilePhoto']} ${styles['profilePhoto']}`}
+            alt="github user profile image"
+            style={style}
+        />
+    )
+}
+
 interface Props {
     githubUsername: string
     createdTimestamp: number
@@ -35,15 +57,7 @@ const UserProfile: React.FC<Props> = ({
 
     return (
         <div className={styles['userContainer']}>
-            {userHasImage && (
-                <img
-                    src={
-                        'https://github.com/' + githubUsername + '.png?size=40'
-                    }
-                    className={`${styles['userProfilePhoto']} ${styles['profilePhoto']}`}
-                    alt="github user profile image"
-                />
-            )}
+            {userHasImage && <UserIcon githubUsername={githubUsername} />}
             <div className={styles['usernameAndTimeContainer']}>
                 <a
                     href={'https://github.com/' + githubUsername}

--- a/source/view/app/components/annotationReference.tsx
+++ b/source/view/app/components/annotationReference.tsx
@@ -5,7 +5,7 @@
  *
  */
 import { useMediaQuery } from '@material-ui/core'
-import { Checkbox } from '@mui/material'
+import { Checkbox, Tooltip } from '@mui/material'
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward'
 import ArrowDownwardIcon from '@mui/icons-material/ArrowDownward'
 import * as React from 'react'
@@ -186,6 +186,11 @@ const AnnotationReference: React.FC<Props> = ({
             </p>
             <div>
                 {annotation.anchors.map((anchor: AnchorObject, i) => {
+                    const anchorTooltipText = isAnchorAlreadySelected(
+                        anchor.anchorId
+                    )
+                        ? 'Remove anchor from merged annotation'
+                        : 'Add anchor to merged annotation'
                     // consider bringing back prior versions in carousel view -- for now, not bothering
                     return (
                         <div
@@ -193,25 +198,29 @@ const AnnotationReference: React.FC<Props> = ({
                             style={{ display: 'flex' }}
                         >
                             {isMedOrMore && (
-                                <Checkbox
-                                    // Needs work
-                                    onChange={() =>
-                                        isAnchorAlreadySelected(anchor.anchorId)
-                                            ? removeAnchorFromMergeAnnotation(
-                                                  anchor.anchorId,
-                                                  anchor.parentId
-                                              )
-                                            : partSelected('anchor', anchor)
-                                    }
-                                    inputProps={{
-                                        'aria-label': 'controlled',
-                                    }}
-                                    checked={
-                                        isAnchorAlreadySelected(
-                                            anchor.anchorId
-                                        ) ?? false
-                                    }
-                                />
+                                <Tooltip title={anchorTooltipText}>
+                                    <Checkbox
+                                        // Needs work
+                                        onChange={() =>
+                                            isAnchorAlreadySelected(
+                                                anchor.anchorId
+                                            )
+                                                ? removeAnchorFromMergeAnnotation(
+                                                      anchor.anchorId,
+                                                      anchor.parentId
+                                                  )
+                                                : partSelected('anchor', anchor)
+                                        }
+                                        inputProps={{
+                                            'aria-label': 'controlled',
+                                        }}
+                                        checked={
+                                            isAnchorAlreadySelected(
+                                                anchor.anchorId
+                                            ) ?? false
+                                        }
+                                    />
+                                </Tooltip>
                             )}
                             <div
                                 id={anchor.parentId + '%' + anchor.anchorId}
@@ -250,15 +259,25 @@ const AnnotationReference: React.FC<Props> = ({
                         }
                     >
                         {isAnnotationTextAlreadySelected() ? (
-                            <ArrowDownwardIcon
-                                onClick={bringBackAnnotation}
-                                style={{ cursor: 'pointer' }}
-                            />
+                            <Tooltip
+                                title={
+                                    'Remove text from merged annotation body'
+                                }
+                            >
+                                <ArrowDownwardIcon
+                                    onClick={bringBackAnnotation}
+                                    style={{ cursor: 'pointer' }}
+                                />
+                            </Tooltip>
                         ) : (
-                            <ArrowUpwardIcon
-                                onClick={elevateAnnotation}
-                                style={{ cursor: 'pointer' }}
-                            />
+                            <Tooltip
+                                title={'Add text to merged annotation body'}
+                            >
+                                <ArrowUpwardIcon
+                                    onClick={elevateAnnotation}
+                                    style={{ cursor: 'pointer' }}
+                                />
+                            </Tooltip>
                         )}
 
                         <div

--- a/source/view/app/components/mergeAnnotations.tsx
+++ b/source/view/app/components/mergeAnnotations.tsx
@@ -910,10 +910,10 @@ const MergeAnnotations: React.FC<Props> = ({
                     internalAnnotationBodyRepresentation.length
                         ? findSurroundingAnnotationBodyMetaData(userAddition)
                         : null
-                console.log(
-                    'hewwwoooooo?????',
-                    internalAnnotationBodyRepresentation
-                )
+                // console.log(
+                //     'hewwwoooooo?????',
+                //     internalAnnotationBodyRepresentation
+                // )
                 let baseInternal: AnnotationBodyLocationMetaData = {
                     source: AnnotationBodySources.User,
                     annoId: userAddition.id,
@@ -929,7 +929,7 @@ const MergeAnnotations: React.FC<Props> = ({
                 let partitionB: AnnotationBodyLocationMetaData | null = null
                 let didPartition = false
                 let didAddToText = false
-                console.log('surrounding', surroundingMetadata)
+                // console.log('surrounding', surroundingMetadata)
                 if (
                     surroundingMetadata &&
                     surroundingMetadata.otherInformation &&
@@ -1999,6 +1999,13 @@ const MergeAnnotations: React.FC<Props> = ({
             checkMapForAnchorDuplicates(annoId, anchorId)
         )
 
+        if (anchorsToRemove.some((a) => a.annoId === 'temp-merge')) {
+            vscode.postMessage({
+                command: 'removeTempMergeAnchor',
+                anchorsToRemove,
+            })
+        }
+
         const ids = anchorsToRemove.map((a) => a.anchorId)
         let newAnchorList = newAnnotation.anchors.filter(
             (a) => !ids.includes(a.anchorId)
@@ -2069,7 +2076,7 @@ const MergeAnnotations: React.FC<Props> = ({
                                     i +
                                     'merge-anchor-list-delete'
                                 }
-                                name="Delete"
+                                name="Remove anchor from merged annotation"
                                 icon={<DeleteIcon fontSize="small" />}
                             />
                         </div>
@@ -2114,38 +2121,40 @@ const MergeAnnotations: React.FC<Props> = ({
                                     justifyContent: 'space-between',
                                 }}
                             >
-                                <AnnotationTypesBar
-                                    currentTypes={types}
-                                    editTypes={updateAnnotationTypes}
-                                />
-                                <div>
-                                    <Checkbox
-                                        onChange={() =>
-                                            !getAllAnnotation
-                                                ? getAllAnnotationContent()
-                                                : removeAllAnnotationContent()
-                                        }
-                                        inputProps={{
-                                            'aria-label': 'controlled',
-                                        }}
-                                        checked={getAllAnnotation}
-                                    />
-                                    Add all annotation bodies?
-                                </div>
-                                <div>
-                                    <Checkbox
-                                        onChange={() =>
-                                            !getAllReplies
-                                                ? getAllReplyContent()
-                                                : removeAllReplyContent()
-                                        }
-                                        inputProps={{
-                                            'aria-label': 'controlled',
-                                        }}
-                                        checked={getAllReplies}
-                                    />
-                                    Add all replies?
-                                </div>
+                                {annotations.some(
+                                    (a) => a.annotation !== ''
+                                ) ? (
+                                    <div>
+                                        <Checkbox
+                                            onChange={() =>
+                                                !getAllAnnotation
+                                                    ? getAllAnnotationContent()
+                                                    : removeAllAnnotationContent()
+                                            }
+                                            inputProps={{
+                                                'aria-label': 'controlled',
+                                            }}
+                                            checked={getAllAnnotation}
+                                        />
+                                        Add all annotation bodies?
+                                    </div>
+                                ) : null}
+                                {annotations.some((a) => a.replies.length) ? (
+                                    <div>
+                                        <Checkbox
+                                            onChange={() =>
+                                                !getAllReplies
+                                                    ? getAllReplyContent()
+                                                    : removeAllReplyContent()
+                                            }
+                                            inputProps={{
+                                                'aria-label': 'controlled',
+                                            }}
+                                            checked={getAllReplies}
+                                        />
+                                        Add all replies?
+                                    </div>
+                                ) : null}
                                 <CatseyeButton
                                     buttonClicked={addAnchor}
                                     name="Add Anchor"
@@ -2155,6 +2164,10 @@ const MergeAnnotations: React.FC<Props> = ({
                             {newAnnotation.anchors.length > 0
                                 ? renderAnchors()
                                 : null}
+                            <AnnotationTypesBar
+                                currentTypes={types}
+                                editTypes={updateAnnotationTypes}
+                            />
                             <TextEditor
                                 content={
                                     printInternalAnnotationBodyRepresentation
@@ -2196,7 +2209,12 @@ const MergeAnnotations: React.FC<Props> = ({
                                     annotation: '',
                                 }
                             return (
-                                <Grid item xs={4} md={6}>
+                                <Grid
+                                    key={'grid-item-' + a.id}
+                                    item
+                                    xs={4}
+                                    md={6}
+                                >
                                     <AnnotationReference
                                         key={`merge-tsx-` + a.id}
                                         annotation={a}

--- a/source/view/app/components/mergeAnnotations.tsx
+++ b/source/view/app/components/mergeAnnotations.tsx
@@ -976,7 +976,7 @@ const MergeAnnotations: React.FC<Props> = ({
                         surroundingMetadata.insertionType ===
                             InsertionType.Inside
                     ) {
-                        console.log('in if!')
+                        // console.log('in if!')
                         didPartition = true
                         const objWerePartitioning =
                             internalAnnotationBodyRepresentation[
@@ -1999,12 +1999,10 @@ const MergeAnnotations: React.FC<Props> = ({
             checkMapForAnchorDuplicates(annoId, anchorId)
         )
 
-        if (anchorsToRemove.some((a) => a.annoId === 'temp-merge')) {
-            vscode.postMessage({
-                command: 'removeTempMergeAnchor',
-                anchorsToRemove,
-            })
-        }
+        vscode.postMessage({
+            command: 'removeTempMergeAnchor',
+            anchorsToRemove,
+        })
 
         const ids = anchorsToRemove.map((a) => a.anchorId)
         let newAnchorList = newAnnotation.anchors.filter(

--- a/source/view/app/components/newAnnotation.tsx
+++ b/source/view/app/components/newAnnotation.tsx
@@ -21,17 +21,19 @@ import AnnotationTypesBar from './annotationComponents/annotationTypesBar'
 import AnchorIcon from '@mui/icons-material/Anchor'
 import CatseyeButton from './annotationComponents/CatseyeButton'
 import { PastVersion } from './annotationComponents/pastVersions'
-import { AnchorObject, Type } from '../../../constants/constants'
+import { Anchor, AnchorObject, Type } from '../../../constants/constants'
 import { createAnchorOnCommitFromAnchorObject } from './annotationComponents/anchorCarousel'
 
 interface Props {
-    anchorObject: AnchorObject
+    newAnchors: AnchorObject[]
+    newAnnoId: string
     vscode: any
     notifyDone: () => void
 }
 
 const NewAnnotation: React.FC<Props> = ({
-    anchorObject,
+    newAnchors,
+    newAnnoId,
     vscode,
     notifyDone = () => {},
 }) => {
@@ -75,12 +77,12 @@ const NewAnnotation: React.FC<Props> = ({
         breakpoints: breakpoints,
     })
 
-    const scrollWithRangeAndFile = (e: React.SyntheticEvent): void => {
-        e.stopPropagation()
+    const scrollWithRangeAndFile = (anchor: Anchor, gitUrl: string): void => {
+        // e.stopPropagation()
         vscode.postMessage({
             command: 'scrollWithRangeAndFile',
-            anchor: anchorObject.anchor,
-            gitUrl: anchorObject.stableGitUrl,
+            anchor,
+            gitUrl,
         })
     }
 
@@ -111,11 +113,10 @@ const NewAnnotation: React.FC<Props> = ({
     }
 
     const addAnchor = (): void => {
-        console.log('We should add an anchor using the specified methods here!')
-        // vscode.postMessage({
-        //     command: 'addAnchor',
-        //     annoId: id,
-        // })
+        vscode.postMessage({
+            command: 'addAnchor',
+            annoId: newAnnoId,
+        })
     }
 
     return (
@@ -128,14 +129,21 @@ const NewAnnotation: React.FC<Props> = ({
             <ThemeProvider theme={theme}>
                 <Card style={cardStyle}>
                     <CardContent>
-                        {/* <Syntax html={selection} /> */}
-                        <PastVersion
-                            handleClick={scrollWithRangeAndFile}
-                            i={0}
-                            pastVersion={createAnchorOnCommitFromAnchorObject(
-                                anchorObject
-                            )}
-                        />
+                        {newAnchors.map((a) => (
+                            <PastVersion
+                                key={'new-anno-' + a.anchorId}
+                                handleClick={() =>
+                                    scrollWithRangeAndFile(
+                                        a.anchor,
+                                        a.stableGitUrl
+                                    )
+                                }
+                                i={0}
+                                pastVersion={createAnchorOnCommitFromAnchorObject(
+                                    a
+                                )}
+                            />
+                        ))}
 
                         <div className={styles['ContentContainer']}>
                             <div

--- a/source/view/app/components/topbar.tsx
+++ b/source/view/app/components/topbar.tsx
@@ -24,7 +24,10 @@ import {
     ThemeProvider,
 } from '@mui/material'
 import { vscodeTextColor } from '../styles/vscodeStyles'
-import { defaultFilterOptions } from '../utils/viewUtilsTsx'
+import {
+    defaultFilterOptions,
+    renderAuthorOptions,
+} from '../utils/viewUtilsTsx'
 import ScopeMenu from './topbarComponents/scopeMenu'
 
 interface Props {
@@ -32,6 +35,7 @@ interface Props {
     // showKeyboardShortcuts: () => void
     filtersUpdated: (filters: FilterOptions) => void
     vscode: any
+    githubUsername: string
 }
 // Add a bell/notification
 const TopBar: React.FC<Props> = ({
@@ -39,9 +43,19 @@ const TopBar: React.FC<Props> = ({
     // showKeyboardShortcuts,
     filtersUpdated,
     vscode,
+    githubUsername,
 }) => {
     const [filterOptions, setFilterOptions] =
         React.useState<FilterOptions>(defaultFilterOptions)
+
+    React.useEffect(() => {
+        if (githubUsername) {
+            setFilterOptions({
+                ...filterOptions,
+                authorOptions: renderAuthorOptions(githubUsername),
+            })
+        }
+    }, [githubUsername])
 
     const annotationTypesUpdated = (newOptions: OptionGroup): void => {
         const newFilterOptions = { ...filterOptions, typeOptions: newOptions }
@@ -82,10 +96,6 @@ const TopBar: React.FC<Props> = ({
         }
         setFilterOptions(newFilterOptions)
         filtersUpdated(newFilterOptions)
-        console.log('posting message', {
-            command: 'showResolvedUpdated',
-            showResolved: !filterOptions.showResolved,
-        })
         vscode.postMessage({
             command: 'showResolvedUpdated',
             showResolved: !filterOptions.showResolved,
@@ -148,6 +158,7 @@ const TopBar: React.FC<Props> = ({
             },
         },
     })
+
     return (
         <div className={styles['TopBarContainer']}>
             <ThemeProvider theme={theme}>

--- a/source/view/app/components/topbarComponents/optionChipsBar.tsx
+++ b/source/view/app/components/topbarComponents/optionChipsBar.tsx
@@ -27,6 +27,10 @@ const OptionChipsBar: React.FC<OptionsProps> = ({
 }) => {
     const [options, setOptions] = React.useState<Option[]>(initOptions.options)
 
+    React.useEffect(() => {
+        setOptions(initOptions.options)
+    }, [initOptions])
+
     const theme = createTheme({
         breakpoints: breakpoints,
     })
@@ -82,7 +86,7 @@ const OptionChipsBar: React.FC<OptionsProps> = ({
             {options.map((option: Option, id) => {
                 return (
                     <CustomChip
-                        key={id}
+                        key={'chip' + option.name + id}
                         label={isMedOrMore ? option.name : option.icon}
                         icon={isMedOrMore ? option.icon : undefined}
                         color={option.selected === true ? 'primary' : 'default'}

--- a/source/view/app/styles/annotation.module.css
+++ b/source/view/app/styles/annotation.module.css
@@ -286,8 +286,10 @@
 }
 
 .profilePhoto {
-    width: 30px !important;
-    height: 30px !important;
+    /* width: 30px !important; */
+    /* height: 30px !important; */
+    width: 30px;
+    height: 30px;
 }
 
 .usernameAndTimeContainer {
@@ -316,6 +318,12 @@
     border: 1.5px solid var(--vscode-editor-foreground); */
     margin-top: 8px;
     margin-bottom: 4px;
+}
+
+.inlineReply.textboxContainer {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
 }
 
 .AnchorDescription {
@@ -556,6 +564,10 @@ button.submit:hover {
     filter: brightness(1);
     transition: opacity 0.55s ease-in-out;
     background-color: #7fae42;
+}
+
+button.submit.inlineReply {
+    margin-bottom: 4px;
 }
 
 button.cancel {

--- a/source/view/app/styles/annotation.module.css.d.ts
+++ b/source/view/app/styles/annotation.module.css.d.ts
@@ -45,6 +45,7 @@ interface CssExports {
   'dropdown': string;
   'dropdown-toggle': string;
   'inFocus': string;
+  'inlineReply': string;
   'lastItem': string;
   'multiLine': string;
   'outOfFocus': string;

--- a/source/view/app/utils/viewUtils.ts
+++ b/source/view/app/utils/viewUtils.ts
@@ -9,7 +9,9 @@
 import * as vscode from 'vscode'
 import {
     AnchorObject,
+    AnchorOnCommit,
     Annotation,
+    PotentialAnchorObject,
     Scope,
     Sort,
 } from '../../../constants/constants'
@@ -351,4 +353,32 @@ export function getStringDifference(a: string, b: string): string {
         j++
     }
     return result
+}
+
+export const getActiveIndicatorIconProps = (
+    versionsToRender: AnchorOnCommit[] | PotentialAnchorObject[]
+): any => {
+    return versionsToRender.length === 1
+        ? { display: 'none' }
+        : {
+              color: 'white',
+              '&:hover': {
+                  color: '#7fae4285',
+              },
+              transition: '200ms',
+          }
+}
+
+export const getIndicatorIconProps = (
+    versionsToRender: AnchorOnCommit[] | PotentialAnchorObject[]
+): any => {
+    return versionsToRender.length === 1
+        ? { display: 'none' }
+        : {
+              color: '#e3dfdf91',
+              '&:hover': {
+                  color: '##e3dfdf40',
+              },
+              transition: '200ms',
+          }
 }

--- a/source/view/app/utils/viewUtilsTsx.tsx
+++ b/source/view/app/utils/viewUtilsTsx.tsx
@@ -26,6 +26,7 @@ import TaskIcon from '@mui/icons-material/Task' // Task
 import AssignmentIcon from '@mui/icons-material/Assignment' // Proposal
 import { ContactSupport } from '@mui/icons-material'
 import CodeOffIcon from '@mui/icons-material/CodeOff'
+import { UserIcon } from '../components/annotationComponents/userProfile'
 
 // toggle button used for expanding and collapsing snapshots, etc.
 export const collapseExpandToggle = (
@@ -85,6 +86,32 @@ export const showHideLine = (
             <div className={styles['showHideLineButton']}>{subjectString}</div>
         </div>
     )
+}
+
+export const renderAuthorOptions = (githubUsername: string): OptionGroup => {
+    if (githubUsername) {
+        return {
+            label: 'Author',
+            options: [
+                {
+                    name: githubUsername,
+                    selected: true,
+                    icon: (
+                        <UserIcon
+                            githubUsername={githubUsername}
+                            style={{ width: '20px', height: '20px' }}
+                        />
+                    ),
+                },
+                {
+                    name: AuthorOptions.others,
+                    selected: true,
+                    icon: <Groups fontSize="small" />,
+                },
+            ],
+        }
+    }
+    return defaultAuthorOptions
 }
 
 export const defaultAuthorOptions: OptionGroup = {

--- a/source/viewHelper/viewHelper.ts
+++ b/source/viewHelper/viewHelper.ts
@@ -38,6 +38,8 @@ import {
     setDeletedAnnotationList,
     setEventsToTransmitOnSave,
     setShowResolved,
+    setTempMergedAnchors,
+    tempMergedAnchors,
 } from '../extension'
 import {
     initializeAnnotations,
@@ -165,13 +167,39 @@ export const handleAddAnchor = async (id: string): Promise<void> => {
             id,
             new vscode.Range(currentSelection.start, currentSelection.end)
         )
+        // console.log('newAnchor??', newAnchor)
         if (newAnchor) {
             view?.sendAnchorsToMergeAnnotation([newAnchor], [], [])
+            setTempMergedAnchors(newAnchor)
             const textEditorToHighlight: vscode.TextEditor = vscode.window
                 .activeTextEditor
                 ? vscode.window.activeTextEditor
                 : vscode.window.visibleTextEditors[0]
-            addTempAnnotationHighlight([newAnchor], textEditorToHighlight)
+            addTempAnnotationHighlight(tempMergedAnchors, textEditorToHighlight)
+        } else {
+            console.log('couldnt create anchor')
+        }
+
+        return
+    } else if (tempAnno && tempAnno.id === id) {
+        const newAnchor: AnchorObject | undefined = await createAnchorObject(
+            id,
+            new vscode.Range(currentSelection.start, currentSelection.end)
+        )
+        // console.log('newAnchor??', newAnchor)
+        if (newAnchor) {
+            // view?.sendAnchorsToMergeAnnotation([newAnchor], [], [])
+            setTempAnno({
+                ...tempAnno,
+                anchors: tempAnno.anchors.concat(newAnchor),
+            })
+            setTempMergedAnchors(newAnchor)
+            const textEditorToHighlight: vscode.TextEditor = vscode.window
+                .activeTextEditor
+                ? vscode.window.activeTextEditor
+                : vscode.window.visibleTextEditors[0]
+            addTempAnnotationHighlight(tempMergedAnchors, textEditorToHighlight)
+            view?.sendNewAnchorForNewAnnotation(newAnchor)
         } else {
             console.log('couldnt create anchor')
         }
@@ -420,11 +448,18 @@ export const handleCreateAnnotation = (
                     doc.document.uri.toString() ===
                     tempAnno?.anchors[0].filename
             )
+            const anchorIds = newAnno.anchors.map((a) => a.anchorId)
+            setTempMergedAnchors(
+                tempMergedAnchors.filter((a) => !anchorIds.includes(a.anchorId))
+            )
             setTempAnno(null)
             setAnnotationList(annotationList)
             fbSaveAnnotations(annotationList)
             view?.updateDisplay(annotationList)
-            if (text) addHighlightsToEditor(annotationList, text)
+            if (text) {
+                addHighlightsToEditor(annotationList, text)
+                addTempAnnotationHighlight(tempMergedAnchors, text)
+            }
             if (willBePinned) {
                 setSelectedAnnotationsNavigations([
                     ...selectedAnnotationsNavigations,
@@ -570,6 +605,14 @@ export const handleCancelAnnotation = (): void => {
     // reset temp object and re-render
     setTempAnno(null)
     view?.updateDisplay(removeOutOfDateAnnotations(annotationList))
+    if (tempMergedAnchors.length) {
+        setTempMergedAnchors([])
+        addTempAnnotationHighlight(
+            [],
+            vscode.window.activeTextEditor ??
+                vscode.window.visibleTextEditors[0]
+        )
+    }
 }
 
 // NOT USED ANYMORE
@@ -710,11 +753,11 @@ export const handleMergeAnnotation = (
     setAnnotationList([
         ...annotationList.filter((a) => !ids.includes(a.id)),
         newAnnotation,
-        // ...mergedAnnotations,
     ])
     const newEvent = createEvent(mergedAnnotations, EventType.merge)
     emitEvent(newEvent)
     view?.updateDisplay(annotationList)
+    setTempMergedAnchors([])
     vscode.window.visibleTextEditors.forEach((t) => {
         addHighlightsToEditor(annotationList, t)
         addTempAnnotationHighlight([], t)
@@ -857,6 +900,11 @@ export const handleFindMatchingAnchors = (annotations: Annotation[]): void => {
         anchorsThatWereUsedButNotTransmitting,
         annoIdArr
     )
+    setTempMergedAnchors(anchorObjs)
+    addTempAnnotationHighlight(
+        anchorObjs,
+        vscode.window.activeTextEditor ?? vscode.window.visibleTextEditors[0]
+    )
 }
 
 export const handleReanchor = (
@@ -969,4 +1017,19 @@ export const handleShowResolvedUpdated = (showResolved: boolean): void => {
 export const handleOpenDocumentation = (): void => {
     vscode.env.openExternal(vscode.Uri.parse('https://www.catseye.tech'))
     return
+}
+
+export const handleRemoveTempMergeAnchor = (
+    anchorsToRemove: AnnotationAnchorPair[]
+): void => {
+    const anchorIds = anchorsToRemove.map((a) => a.anchorId)
+    const tempAnchorsToHighlight = tempMergedAnchors.filter(
+        (a) => !anchorIds.includes(a.anchorId)
+    )
+    setTempMergedAnchors(tempAnchorsToHighlight)
+    const textEditorToHighlight: vscode.TextEditor = vscode.window
+        .activeTextEditor
+        ? vscode.window.activeTextEditor
+        : vscode.window.visibleTextEditors[0]
+    addTempAnnotationHighlight(tempMergedAnchors, textEditorToHighlight)
 }

--- a/source/viewHelper/viewHelper.ts
+++ b/source/viewHelper/viewHelper.ts
@@ -588,10 +588,10 @@ export const handleDeleteResolveAnnotation = (
             annotationUrls.includes(getStableGitHubUrl(v.document.uri.fsPath))
     )[0]
 
-    setAnnotationList(removeOutOfDateAnnotations(updatedList))
-    view?.updateDisplay(annotationList)
+    setAnnotationList(updatedList)
+    view?.updateDisplay(updatedList)
     if (visible) {
-        addHighlightsToEditor(annotationList, visible)
+        addHighlightsToEditor(updatedList, visible)
     }
     if (selectedAnnotationsNavigations.map((a) => a.id).includes(id)) {
         setSelectedAnnotationsNavigations(


### PR DESCRIPTION
Lots of little QOL fixes including:

- Add anchor/unanchored icons to expanded annotation view
- Add user icon to collapsed view
- Change Author filter with the actual user ID and photo
- “Manually reanchor” - have text and icon together
- White for active, gray for not active in anchor carousel
- Move “submit” for reply up to right, wrap button down if need be (narrow pane)
- Hover – move to cursor location as opposed to anchor location
- Arrow icons should have hover text
- Move annotation types above text body
- temporary highlights for new annotation and merged annotation anchor points